### PR TITLE
add build function and fix cache volumes

### DIFF
--- a/dagger-docs/dagger.json
+++ b/dagger-docs/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "v0.9.9"
+  "engineVersion": "v0.9.10"
 }

--- a/dagger-docs/dagger/main.go
+++ b/dagger-docs/dagger/main.go
@@ -4,24 +4,17 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 )
 
-type DaggerDocs struct {}
+type DaggerDocs struct{}
 
 // example usage
 // dagger -m github.com/vikram-dagger/daggerverse/dagger-docs call deploy --source ./dagger --project user-experiments --location us-central1 --repository user-test --credential env:GOOGLE_CREDENTIAL
 func (m *DaggerDocs) Deploy(source *Directory, project string, location string, repository string, credential *Secret) (string, error) {
-
 	ctx := context.Background()
 
-	build := dag.Container().
-		From("node:21").
-		WithDirectory("/home/node", source).
-		WithWorkdir("/home/node/docs").
-		WithMountedCache("/src/node_modules", dag.CacheVolume("node-21-modules")).
-		WithExec([]string{"npm", "install"}).
-		WithExec([]string{"npm", "run", "build"}).
-		Directory("./build")
+	build := m.Build(source)
 
 	registry := fmt.Sprintf("%s-docker.pkg.dev/%s/%s/dagger-docs", location, project, repository)
 	split := strings.Split(registry, "/")
@@ -30,9 +23,24 @@ func (m *DaggerDocs) Deploy(source *Directory, project string, location string, 
 		WithExposedPort(80).
 		WithRegistryAuth(split[0], "_json_key", credential).
 		Publish(ctx, registry)
-	if (err != nil) {
+	if err != nil {
 		panic(err)
 	}
 
 	return dag.GoogleCloudRun().CreateService(ctx, project, location, address, 80, credential)
+}
+
+// example usage
+// dagger -m github.com/vikram-dagger/daggerverse/dagger-docs call build --source ./dagger
+func (m *DaggerDocs) Build(source *Directory) *Directory {
+	return dag.Container().
+		From("node:21").
+		WithDirectory("/home/node", source).
+		WithWorkdir("/home/node/docs").
+		WithMountedCache("/home/node/docs/node_modules", dag.CacheVolume("node-21-modules")).
+		WithMountedCache("/home/node/.npm", dag.CacheVolume("npm-cache")).
+		WithExec([]string{"npm", "install"}).
+		WithEnvVariable("CACHE", time.Now().String()).
+		WithExec([]string{"npm", "run", "build"}).
+		Directory("./build")
 }


### PR DESCRIPTION
this PR adds a separate `build` function to only build the docs. It also fixes the cache volumes so when you run `build` multiple times, the build process takes a few seconds instead of minutes since it'll use the correct cache volume now.